### PR TITLE
execute goreleaser —snapshot on every commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,24 @@ jobs:
       - run: goreleaser --rm-dist
       - store_artifacts:
           path: /go/src/github.com/cloudradar-monitoring/csender/dist
+  
+  goreleasse-test:
+    docker:
+      - image: cloudradario/go-build:0.0.5
+    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    steps:
+      - checkout
+      - run: goreleaser --snapshot
 
 workflows:
   version: 2
   test-on-commit:
     jobs:
       - test:
+          filters:
+            tags:
+              ignore: /.*/
+      - goreleasse-test:
           filters:
             tags:
               ignore: /.*/


### PR DESCRIPTION
To be sure that build works on all platforms we run goreleaser --snapshot on every commit